### PR TITLE
Bugfix: IAM Bucket Permissions 

### DIFF
--- a/service_account.tf
+++ b/service_account.tf
@@ -19,6 +19,8 @@ resource "google_project_iam_custom_role" "enrichment_project_role" {
   permissions = [
     "storage.objects.create",
     "storage.objects.delete",
+    "storage.objects.list",
+    "storage.objects.get",
     "run.executions.cancel",
     "run.jobs.run",
     "run.routes.invoke"


### PR DESCRIPTION
# Description

Service Account GCS permissions were missing required `list` and `get`

## Type of change

Please delete options that are not relevant.

- [X] Bug Fix
- [ ] New Feature
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested successfully in Corelight GCP project
