### PR TITLE
Made the GCP project configurable as a variable so it doesn't have to be set in the provider

### DIFF
--- a/cloud_run.tf
+++ b/cloud_run.tf
@@ -1,5 +1,6 @@
 resource "google_cloud_run_v2_service" "enrichment_service" {
   name     = var.cloud_run_service_name
+  project  = var.project_id
   location = var.location
   ingress  = "INGRESS_TRAFFIC_INTERNAL_ONLY"
 
@@ -17,7 +18,7 @@ resource "google_cloud_run_v2_service" "enrichment_service" {
         container_port = "8080"
       }
       env {
-        name  = "REGIONS"
+        name = "REGIONS"
         value = join(",", var.cloud_run_locations)
       }
       env {

--- a/cloud_run.tf
+++ b/cloud_run.tf
@@ -18,7 +18,7 @@ resource "google_cloud_run_v2_service" "enrichment_service" {
         container_port = "8080"
       }
       env {
-        name = "REGIONS"
+        name  = "REGIONS"
         value = join(",", var.cloud_run_locations)
       }
       env {

--- a/cloud_scheduler.tf
+++ b/cloud_scheduler.tf
@@ -1,5 +1,6 @@
 resource "google_cloud_scheduler_job" "enrichment_collection_scheduler_job" {
   name             = var.scheduler_job_name
+  project          = var.project_id
   region           = var.location
   description      = "Invoke Corelight Cloud Enrichment Synchronization"
   schedule         = var.scheduler_job_cron

--- a/pubsub.tf
+++ b/pubsub.tf
@@ -37,6 +37,6 @@ resource "google_pubsub_subscription" "sub" {
     }
   }
 
-  labels = var.labels
+  labels     = var.labels
   depends_on = [google_cloud_run_v2_service.enrichment_service]
 }

--- a/pubsub.tf
+++ b/pubsub.tf
@@ -17,14 +17,15 @@ resource "google_cloud_asset_folder_feed" "folder_feed" {
 
 resource "google_pubsub_topic" "feed_output" {
   name                       = var.topic_name
+  project                    = var.project_id
   message_retention_duration = var.message_retention_duration
-
-  labels = var.labels
+  labels                     = var.labels
 }
 
 resource "google_pubsub_subscription" "sub" {
-  name  = var.pubsub_subscription_name
-  topic = google_pubsub_topic.feed_output.id
+  name    = var.pubsub_subscription_name
+  project = var.project_id
+  topic   = google_pubsub_topic.feed_output.id
 
   push_config {
     push_endpoint = "${google_cloud_run_v2_service.enrichment_service.uri}/event"
@@ -36,6 +37,6 @@ resource "google_pubsub_subscription" "sub" {
     }
   }
 
-  labels     = var.labels
+  labels = var.labels
   depends_on = [google_cloud_run_v2_service.enrichment_service]
 }

--- a/service_account.tf
+++ b/service_account.tf
@@ -5,9 +5,9 @@ resource "google_service_account" "service_account" {
 }
 
 resource "google_folder_iam_binding" "folder_binding" {
-  folder = var.folder_id
+  folder  = var.folder_id
   members = ["serviceAccount:${google_service_account.service_account.email}"]
-  role   = var.organization_role_id
+  role    = var.organization_role_id
 }
 
 resource "google_storage_bucket_iam_member" "gcs_access" {
@@ -36,5 +36,5 @@ resource "google_cloud_run_service_iam_binding" "enrichment_permissions" {
   project  = var.project_id
   location = var.location
   service  = google_cloud_run_v2_service.enrichment_service.name
-  members = ["serviceAccount:${google_service_account.service_account.email}"]
+  members  = ["serviceAccount:${google_service_account.service_account.email}"]
 }

--- a/service_account.tf
+++ b/service_account.tf
@@ -1,12 +1,13 @@
 resource "google_service_account" "service_account" {
   account_id   = var.service_account_id
+  project      = var.project_id
   display_name = var.service_account_display_name
 }
 
 resource "google_folder_iam_binding" "folder_binding" {
-  folder  = var.folder_id
+  folder = var.folder_id
   members = ["serviceAccount:${google_service_account.service_account.email}"]
-  role    = var.organization_role_id
+  role   = var.organization_role_id
 }
 
 resource "google_storage_bucket_iam_member" "gcs_access" {
@@ -16,6 +17,7 @@ resource "google_storage_bucket_iam_member" "gcs_access" {
 }
 
 resource "google_project_iam_custom_role" "enrichment_project_role" {
+  project = var.project_id
   permissions = [
     "storage.objects.create",
     "storage.objects.delete",
@@ -31,7 +33,8 @@ resource "google_project_iam_custom_role" "enrichment_project_role" {
 
 resource "google_cloud_run_service_iam_binding" "enrichment_permissions" {
   role     = google_project_iam_custom_role.enrichment_project_role.name
+  project  = var.project_id
   location = var.location
   service  = google_cloud_run_v2_service.enrichment_service.name
-  members  = ["serviceAccount:${google_service_account.service_account.email}"]
+  members = ["serviceAccount:${google_service_account.service_account.email}"]
 }


### PR DESCRIPTION
# Description

Made the GCP project configurable as a variable so it doesn't have to be set in the provider.

Fixes issue #8 

## Type of change

Please delete options that are not relevant.

- [x] Bug Fix
- [ ] New Feature
- [ ] This change requires a documentation update

# How Has This Been Tested?

Deployed and destroyed successfully
